### PR TITLE
Added support for iOS 13 and arm64e

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+## OS X
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+## Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+## THEOS
+.theos
+/packages

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-export TARGET = iphone:clang:latest:latest
 export ARCHS = armv7 arm64 arm64e
+export TARGET = iphone:clang::10
 
 PACKAGE_VERSION = $(THEOS_PACKAGE_BASE_VERSION)
 FINAL_PACKAGE = 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-export ARCHS = armv7 arm64
 export TARGET = iphone:clang:latest:latest
+export ARCHS = armv7 arm64 arm64e
 
 PACKAGE_VERSION = $(THEOS_PACKAGE_BASE_VERSION)
 FINAL_PACKAGE = 1

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -9,3 +9,10 @@
 	return nil;
 }
 %end
+
+//	iOS 13
+%hook SBHHomeScreenSettings
+-(bool)showWidgets {
+	return NO;
+}
+%end


### PR DESCRIPTION
I've noticed that your tweak doesn't support iOS 13 And since i've figured out what is needed in my tweak - [HomeScreenQuickActions](https://github.com/tomaszpoliszuk/HomeScreenQuickActions) i've decided to send you pull request.

I've also updated Makefile to compile properly for older iOS versions (and arm64e).